### PR TITLE
.show() returns noty instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,13 +17,19 @@ const VueNoty = {
     return this
   },
 
+  create (params) {
+    return new Noty(params)
+  },
+
   show (text, type = 'alert', opts = {}) {
     const params = Object.assign({}, this.options, opts, {
       type,
       text
     })
 
-    return new Noty(params).show()
+    const noty = this.create(params)
+    noty.show()
+    return noty
   },
 
   success (text, opts = {}) {


### PR DESCRIPTION
Sometimes it may be useful for further notification instance manipulations (`.close()` `.stop()` `.resume()`) and so on.